### PR TITLE
Set discount correctly in case of autodiscount

### DIFF
--- a/cividiscount.php
+++ b/cividiscount.php
@@ -432,6 +432,7 @@ function cividiscount_civicrm_buildAmount($pageType, &$form, &$amounts) {
                   }
                 }
               }
+              $appliedDiscountID = $discountID;
               $discountApplied = TRUE;
             }
           }
@@ -449,15 +450,14 @@ function cividiscount_civicrm_buildAmount($pageType, &$form, &$amounts) {
       }
     }
 
-    // this seems to incorrectly set to only the last discount but it seems not to matter in the way it is used
-    if (isset($discountApplied) && $discountApplied) {
+    if (isset($discountApplied) && $discountApplied && !empty($discounts[$appliedDiscountID])) {
       if (!empty($ps['fields'])) {
         $ps['fields'] = $amounts;
         $form->setVar('_priceSet', $ps);
       }
 
       $form->set('_discountInfo', array(
-        'discount' => $discount,
+        'discount' => $discounts[$appliedDiscountID],
         'autodiscount' => $autodiscount,
         'contact_id' => $contact_id,
       ));


### PR DESCRIPTION
Steps to reproduce - 

1. Create a discount code for one event (say `test event`) with Contact type `Individual` in Automatic discount panel (so that this applies to all individuals registering to this event).

2. Create another discount code for all events with any discount amount.

3. Navigate to test event page - Notice that discount 1 has applied automatically.

4. Complete the registration process.

Open `cividiscount_track` table and check that item id recorded for the participant is the id of discount created at step 2. It should contain the value of discount 1.