### PR TITLE
Add "Active" column to discount codes table

### DIFF
--- a/templates/CRM/CiviDiscount/Page/List.tpl
+++ b/templates/CRM/CiviDiscount/Page/List.tpl
@@ -37,23 +37,23 @@
         <thead>
         <tr>
           <th id="sortable">{ts}Name / Description{/ts}</th>
-          <th>{ts}Active{/ts}</th>
           <th>{ts}Amount{/ts}</th>
           <th>{ts}Usage{/ts}</th>
           <th>{ts}Start Date{/ts}</th>
           <th>{ts}End Date{/ts}</th>
+          <th>{ts}Enabled?{/ts}</th>
           <th></th>
         </tr>
         </thead>
         {foreach from=$rows item=row}
           <tr id="discount_code-{$row.id}" class="crm-entity {$row.class}{if NOT $row.is_active} disabled{/if}">
             <td class="crm-discount-code">{$row.code} <br/> {$row.description}</td>
-            <td>{if $row.is_active eq 1}Yes{else}No{/if}</td>
             <td class="right">{if $row.amount_type eq '1'}{$row.amount} %{else}{$row.amount|crmMoney}{/if}</td>
             <td class="right"><a href='{crmURL p='civicrm/cividiscount/report' q="id=`$row.id`&reset=1"}'>{$row.count_use}</a>
               / {if $row.count_max eq 0}{ts}Unlimited{/ts}{else}{$row.count_max}{/if}</td>
             <td>{if $row.active_on neq '0000-00-00 00:00:00'}{$row.active_on|truncate:10:''|crmDate}{/if}</td>
             <td>{if $row.expire_on neq '0000-00-00 00:00:00'}{$row.expire_on|truncate:10:''|crmDate}{/if}</td>
+            <td>{if $row.is_active eq 1}Yes{else}No{/if}</td>
             <td>{$row.action|replace:'xx':$row.id}</td>
           </tr>
         {/foreach}

--- a/templates/CRM/CiviDiscount/Page/List.tpl
+++ b/templates/CRM/CiviDiscount/Page/List.tpl
@@ -37,6 +37,7 @@
         <thead>
         <tr>
           <th id="sortable">{ts}Name / Description{/ts}</th>
+          <th>{ts}Active{/ts}</th>
           <th>{ts}Amount{/ts}</th>
           <th>{ts}Usage{/ts}</th>
           <th>{ts}Start Date{/ts}</th>
@@ -47,6 +48,7 @@
         {foreach from=$rows item=row}
           <tr id="discount_code-{$row.id}" class="crm-entity {$row.class}{if NOT $row.is_active} disabled{/if}">
             <td class="crm-discount-code">{$row.code} <br/> {$row.description}</td>
+            <td>{if $row.is_active eq 1}Yes{else}No{/if}</td>
             <td class="right">{if $row.amount_type eq '1'}{$row.amount} %{else}{$row.amount|crmMoney}{/if}</td>
             <td class="right"><a href='{crmURL p='civicrm/cividiscount/report' q="id=`$row.id`&reset=1"}'>{$row.count_use}</a>
               / {if $row.count_max eq 0}{ts}Unlimited{/ts}{else}{$row.count_max}{/if}</td>


### PR DESCRIPTION
This makes it easier to manage discount codes when you have a whole lot of them and many of them are disabled.

### Before 

* Active discount codes are visually indistinguishable from inactive ones.
* There is no way to view a list of all active discount codes. 

![screenshot51](https://user-images.githubusercontent.com/42411/26898020-bf6cb724-4b87-11e7-81bd-af96e037e7f3.png)

### After 

* A new column shows the status of each code.
* Users can sort by this column to show only the active codes.

![screenshot53](https://user-images.githubusercontent.com/42411/26904577-cf3af95a-4b9f-11e7-93d2-95ff69cbcae7.png)


Fixes #182 