### PR TITLE
I18n E::ts() support

### DIFF
--- a/CRM/CiviDiscount/DAO/Item.php
+++ b/CRM/CiviDiscount/DAO/Item.php
@@ -25,6 +25,8 @@
 +--------------------------------------------------------------------+
 */
 
+use CRM_CiviDiscount_ExtensionUtil as E;
+
 /**
  * @package CiviDiscount
  */
@@ -225,7 +227,7 @@ class CRM_CiviDiscount_DAO_Item extends CRM_Core_DAO {
         'code' => array(
           'name' => 'code',
           'type' => CRM_Utils_Type::T_STRING,
-          'title' => ts('Code'),
+          'title' => E::ts('Code'),
           'required' => TRUE,
           'maxlength' => 255,
           'size' => CRM_Utils_Type::HUGE,
@@ -233,7 +235,7 @@ class CRM_CiviDiscount_DAO_Item extends CRM_Core_DAO {
         'description' => array(
           'name' => 'description',
           'type' => CRM_Utils_Type::T_STRING,
-          'title' => ts('Description'),
+          'title' => E::ts('Description'),
           'required' => TRUE,
           'maxlength' => 255,
           'size' => CRM_Utils_Type::HUGE,
@@ -241,7 +243,7 @@ class CRM_CiviDiscount_DAO_Item extends CRM_Core_DAO {
         'filters' => array(
           'name' => 'filters',
           'type' => CRM_Utils_Type::T_STRING,
-          'title' => ts('Discount Filters'),
+          'title' => E::ts('Discount Filters'),
           'required' => FALSE,
           'maxlength' => 255,
           'size' => CRM_Utils_Type::HUGE,
@@ -249,7 +251,7 @@ class CRM_CiviDiscount_DAO_Item extends CRM_Core_DAO {
         'amount' => array(
           'name' => 'amount',
           'type' => CRM_Utils_Type::T_STRING,
-          'title' => ts('Amount'),
+          'title' => E::ts('Amount'),
           'required' => TRUE,
           'maxlength' => 255,
           'size' => CRM_Utils_Type::HUGE,
@@ -257,7 +259,7 @@ class CRM_CiviDiscount_DAO_Item extends CRM_Core_DAO {
         'amount_type' => array(
           'name' => 'amount_type',
           'type' => CRM_Utils_Type::T_STRING,
-          'title' => ts('Amount Type'),
+          'title' => E::ts('Amount Type'),
           'required' => TRUE,
           'maxlength' => 4,
           'size' => CRM_Utils_Type::FOUR,
@@ -265,35 +267,35 @@ class CRM_CiviDiscount_DAO_Item extends CRM_Core_DAO {
         'count_max' => array(
           'name' => 'count_max',
           'type' => CRM_Utils_Type::T_INT,
-          'title' => ts('Count Max'),
+          'title' => E::ts('Count Max'),
           'required' => TRUE,
         ),
         'count_use' => array(
           'name' => 'count_use',
           'type' => CRM_Utils_Type::T_INT,
-          'title' => ts('Count Use'),
+          'title' => E::ts('Count Use'),
           'required' => TRUE,
           'default' => 0,
         ),
         'events' => array(
           'name' => 'events',
           'type' => CRM_Utils_Type::T_TEXT,
-          'title' => ts('Events'),
+          'title' => E::ts('Events'),
         ),
         'pricesets' => array(
           'name' => 'pricesets',
           'type' => CRM_Utils_Type::T_TEXT,
-          'title' => ts('Pricesets'),
+          'title' => E::ts('Pricesets'),
         ),
         'memberships' => array(
           'name' => 'memberships',
           'type' => CRM_Utils_Type::T_TEXT,
-          'title' => ts('Memberships'),
+          'title' => E::ts('Memberships'),
         ),
         'autodiscount' => array(
           'name' => 'autodiscount',
           'type' => CRM_Utils_Type::T_TEXT,
-          'title' => ts('Autodiscount'),
+          'title' => E::ts('Autodiscount'),
         ),
         'organization_id' => array(
           'name' => 'organization_id',
@@ -303,12 +305,12 @@ class CRM_CiviDiscount_DAO_Item extends CRM_Core_DAO {
         'active_on' => array(
           'name' => 'active_on',
           'type' => CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME,
-          'title' => ts('Activation Date'),
+          'title' => E::ts('Activation Date'),
         ),
         'expire_on' => array(
           'name' => 'expire_on',
           'type' => CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME,
-          'title' => ts('Expiration Date'),
+          'title' => E::ts('Expiration Date'),
         ),
         'is_active' => array(
           'name' => 'is_active',
@@ -321,7 +323,7 @@ class CRM_CiviDiscount_DAO_Item extends CRM_Core_DAO {
         'discount_msg' => array(
           'name' => 'discount_msg',
           'type' => CRM_Utils_Type::T_STRING,
-          'title' => ts('Discount Message'),
+          'title' => E::ts('Discount Message'),
           'maxlength' => 255,
           'size' => CRM_Utils_Type::HUGE,
         ),

--- a/CRM/CiviDiscount/Form/Admin.php
+++ b/CRM/CiviDiscount/Form/Admin.php
@@ -25,6 +25,8 @@
  +--------------------------------------------------------------------+
 */
 
+use CRM_CiviDiscount_ExtensionUtil as E;
+
 /**
  * @package CiviDiscount
  */
@@ -73,7 +75,7 @@ class CRM_CiviDiscount_Form_Admin extends CRM_Admin_Form {
     );
 
     $this->select2style = array(
-      'placeholder' => ts('- none -'),
+      'placeholder' => E::ts('- none -'),
       'multiple' => TRUE,
       'class' => 'crm-select2 huge',
     );
@@ -152,60 +154,60 @@ class CRM_CiviDiscount_Form_Admin extends CRM_Admin_Form {
     $this->applyFilter('__ALL__', 'trim');
     $element = $this->add('text',
       'code',
-      ts('Discount Code'),
+      E::ts('Discount Code'),
       CRM_Core_DAO::getAttribute('CRM_CiviDiscount_DAO_Item', 'code'),
       TRUE
     );
     $this->addRule('code',
-      ts('Code already exists in Database.'),
+      E::ts('Code already exists in Database.'),
       'objectExists',
       array('CRM_CiviDiscount_DAO_Item', $this->_id, 'code'));
     $this->addRule('code',
-      ts('Code can only consist of alpha-numeric characters'),
+      E::ts('Code can only consist of alpha-numeric characters'),
       'variable');
     if ($this->_action & CRM_Core_Action::UPDATE) {
       $element->freeze();
     }
 
-    $this->add('text', 'description', ts('Description'), CRM_Core_DAO::getAttribute('CRM_CiviDiscount_DAO_Item', 'description'));
+    $this->add('text', 'description', E::ts('Description'), CRM_Core_DAO::getAttribute('CRM_CiviDiscount_DAO_Item', 'description'));
 
-    $this->addMoney('amount', ts('Discount Amount'), TRUE, CRM_Core_DAO::getAttribute('CRM_CiviDiscount_DAO_Item', 'amount'), FALSE);
+    $this->addMoney('amount', E::ts('Discount Amount'), TRUE, CRM_Core_DAO::getAttribute('CRM_CiviDiscount_DAO_Item', 'amount'), FALSE);
 
     $this->add('select', 'amount_type', NULL,
       array(
-        1 => ts('Percent'),
-        2 => ts('Fixed Amount')
+        1 => E::ts('Percent'),
+        2 => E::ts('Fixed Amount')
       ),
       TRUE);
 
-    $this->add('text', 'count_max', ts('Usage Limit'), CRM_Core_DAO::getAttribute('CRM_CiviDiscount_DAO_Item', 'count_max') + array('min' => 1));
-    $this->addRule('count_max', ts('Must be an integer'), 'integer');
+    $this->add('text', 'count_max', E::ts('Usage Limit'), CRM_Core_DAO::getAttribute('CRM_CiviDiscount_DAO_Item', 'count_max') + array('min' => 1));
+    $this->addRule('count_max', E::ts('Must be an integer'), 'integer');
 
-    $this->addDate('active_on', ts('Activation Date'), FALSE);
-    $this->addDate('expire_on', ts('Expiration Date'), FALSE);
+    $this->addDate('active_on', E::ts('Activation Date'), FALSE);
+    $this->addDate('expire_on', E::ts('Expiration Date'), FALSE);
 
-    $this->addEntityRef('organization_id', ts('Organization'), array('api' => array('params' => array('contact_type' => 'Organization'))));
+    $this->addEntityRef('organization_id', E::ts('Organization'), array('api' => array('params' => array('contact_type' => 'Organization'))));
 
     // is this discount active ?
-    $this->addElement('checkbox', 'is_active', ts('Is this discount active?'));
+    $this->addElement('checkbox', 'is_active', E::ts('Is this discount active?'));
 
-    $this->addElement('checkbox', 'discount_msg_enabled', ts('Display a message to users not eligible for this discount?'));
-    $this->add('textarea', 'discount_msg', ts('Message to non-eligible users'), array('class' => 'big'));
+    $this->addElement('checkbox', 'discount_msg_enabled', E::ts('Display a message to users not eligible for this discount?'));
+    $this->add('textarea', 'discount_msg', E::ts('Message to non-eligible users'), array('class' => 'big'));
 
     // add memberships, events, pricesets
     $membershipTypes = CRM_Member_BAO_MembershipType::getMembershipTypes(FALSE);
     if (!empty($membershipTypes)) {
       $this->add('select',
         'memberships',
-        ts('Memberships'),
+        E::ts('Memberships'),
         $membershipTypes,
         FALSE,
         $this->select2style
       );
     }
     $this->assignAutoDiscountFields();
-    $this->addElement('text', 'advanced_autodiscount_filter_entity', ts('Specify entity for advanced autodiscount'));
-    $this->addElement('text', 'advanced_autodiscount_filter_string', ts('Specify api string for advanced filter'), array('class' => 'huge'));
+    $this->addElement('text', 'advanced_autodiscount_filter_entity', E::ts('Specify entity for advanced autodiscount'));
+    $this->addElement('text', 'advanced_autodiscount_filter_string', E::ts('Specify api string for advanced filter'), array('class' => 'huge'));
 
     $events = CRM_CiviDiscount_Utils::getEvents();
     if (!empty($events)) {
@@ -213,7 +215,7 @@ class CRM_CiviDiscount_Form_Admin extends CRM_Admin_Form {
       $this->_multiValued['events'] = $events;
       $this->add('select',
         'events',
-        ts('Events'),
+        E::ts('Events'),
         $events,
         FALSE,
         $this->select2style
@@ -223,7 +225,7 @@ class CRM_CiviDiscount_Form_Admin extends CRM_Admin_Form {
       $this->_multiValued['eventtypes'] = $eventTypes;
       $this->add('select',
         'event_type_id',
-        ts('Event Types'),
+        E::ts('Event Types'),
         $eventTypes,
         FALSE,
         $this->select2style
@@ -235,10 +237,10 @@ class CRM_CiviDiscount_Form_Admin extends CRM_Admin_Form {
       $this->_multiValued['pricesets'] = $pricesets;
       $this->add('select',
         'pricesets',
-        ts('Price Field Options'),
+        E::ts('Price Field Options'),
         $pricesets,
         FALSE,
-        array('placeholder' => ts('- any -')) + $this->select2style
+        array('placeholder' => E::ts('- any -')) + $this->select2style
       );
     }
   }
@@ -263,7 +265,7 @@ class CRM_CiviDiscount_Form_Admin extends CRM_Admin_Form {
         );
         $assignedAutoFilters[] = $autoFilter['form_field_name'];
         if (!empty($autoFilter['rule_data_type'])) {
-          $this->addRule($autoFilter['form_field_name'], ts('Please re-enter ' . $autoFilter['title'] . ' you need to enter an ' . $autoFilter['rule_data_type']), $autoFilter['rule_data_type']);
+          $this->addRule($autoFilter['form_field_name'], E::ts('Please re-enter ' . $autoFilter['title'] . ' you need to enter an ' . $autoFilter['rule_data_type']), $autoFilter['rule_data_type']);
         }
       }
     }
@@ -279,7 +281,7 @@ class CRM_CiviDiscount_Form_Admin extends CRM_Admin_Form {
   public function postProcess() {
     if ($this->_action & CRM_Core_Action::DELETE) {
       CRM_CiviDiscount_BAO_Item::del($this->_id);
-      CRM_Core_Session::setStatus(ts('Selected Discount has been deleted.'), ts('Deleted'), 'success');
+      CRM_Core_Session::setStatus(ts('Selected Discount has been deleted.'), E::ts('Deleted'), 'success');
       return;
     }
 
@@ -287,7 +289,7 @@ class CRM_CiviDiscount_Form_Admin extends CRM_Admin_Form {
       $params = $this->exportValues();
       $newCode = CRM_CiviDiscount_Utils::randomString('abcdefghjklmnpqrstwxyz23456789', 8);
       CRM_CiviDiscount_BAO_Item::copy($this->_cloneID, $params, $newCode);
-      CRM_Core_Session::setStatus(ts('Selected Discount has been duplicated.'), ts('Copied'), 'success');
+      CRM_Core_Session::setStatus(ts('Selected Discount has been duplicated.'), E::ts('Copied'), 'success');
       return;
     }
 
@@ -315,7 +317,7 @@ class CRM_CiviDiscount_Form_Admin extends CRM_Admin_Form {
     $item = CRM_CiviDiscount_BAO_Item::add($params);
 
     CRM_Core_Session::setStatus(ts('The discount \'%1\' has been saved.',
-      array(1 => $item->description ? $item->description : $item->code)), ts('Saved'), 'success');
+      array(1 => $item->description ? $item->description : $item->code)), E::ts('Saved'), 'success');
   }
 
   /**
@@ -617,31 +619,31 @@ class CRM_CiviDiscount_Form_Admin extends CRM_Admin_Form {
     return array(
       'membership' => array(
         'membership_type_id' => array(
-          'title' => ts('Automatic discount for existing members of type'),
+          'title' => E::ts('Automatic discount for existing members of type'),
           'form_field_name' => 'autodiscount_membership_type_id',
           'operator' => 'IN',
           'field_type' => 'select',
           'options' => $this->getOptions('membership', 'membership_type_id'),
         ),
         'status_id' => array(
-          'title' => ts('Automatic discount for Membership Statuses'),
+          'title' => E::ts('Automatic discount for Membership Statuses'),
           'form_field_name' => 'autodiscount_membership_status_id',
           'operator' => 'IN',
           'field_type' => 'select',
-          'options' => array('' => ts('--any current status--')) + $this->getOptions('membership', 'status_id'),
+          'options' => array('' => E::ts('--any current status--')) + $this->getOptions('membership', 'status_id'),
           'defaults_callback' => 'setMembershipStatusDefaults',
         ),
       ),
       'contact' => array(
         'contact_type' => array(
-          'title' => ts('Contact Type'),
+          'title' => E::ts('Contact Type'),
           'form_field_name' => 'autodiscount_contact_type',
           'operator' => 'IN',
           'options' => $this->getOptions('contact', 'contact_type'),
           'field_type' => 'select',
         ),
         'age_low' => array(
-          'title' => ts('Minimum Age'),
+          'title' => E::ts('Minimum Age'),
           'field_type' => 'Text',
           'form_field_name' => 'autodiscount_age_low',
           'rule_data_type' => 'integer',
@@ -649,7 +651,7 @@ class CRM_CiviDiscount_Form_Admin extends CRM_Admin_Form {
           'defaults_callback' => 'setAgeDefaults',
         ),
         'age_high' => array(
-          'title' => ts('Maximum Age'),
+          'title' => E::ts('Maximum Age'),
           'field_type' => 'Text',
           'operator' => '=',// we could make this the adjustment fn name?
           'form_field_name' => 'autodiscount_age_high',
@@ -659,7 +661,7 @@ class CRM_CiviDiscount_Form_Admin extends CRM_Admin_Form {
       ),
       'address' => array(
         'country_id' => array(
-          'title' => ts('Country'),
+          'title' => E::ts('Country'),
           'form_field_name' => 'autodiscount_country_id',
           'operator' => 'IN',
           'field_type' => 'select',

--- a/CRM/CiviDiscount/Page/List.php
+++ b/CRM/CiviDiscount/Page/List.php
@@ -30,6 +30,7 @@
  */
 
 require_once 'CRM/CiviDiscount/DAO/Item.php';
+use CRM_CiviDiscount_ExtensionUtil as E;
 
 /**
  * Page for displaying list of discount codes
@@ -63,38 +64,38 @@ class CRM_CiviDiscount_Page_List extends CRM_Core_Page_Basic {
     if (!(self::$_links)) {
       self::$_links = array(
         CRM_Core_Action::VIEW => array(
-          'name' => ts('View'),
+          'name' => E::ts('View'),
           'url' => 'civicrm/cividiscount/discount/view',
           'qs' => 'id=%%id%%&reset=1',
-          'title' => ts('View Discount Code')
+          'title' => E::ts('View Discount Code')
         ),
         CRM_Core_Action::UPDATE => array(
-          'name' => ts('Edit'),
+          'name' => E::ts('Edit'),
           'url' => 'civicrm/cividiscount/discount/edit',
           'qs' => '&id=%%id%%&reset=1',
-          'title' => ts('Edit Discount Code')
+          'title' => E::ts('Edit Discount Code')
         ),
         CRM_Core_Action::COPY => array(
-          'name' => ts('Copy'),
+          'name' => E::ts('Copy'),
           'url' => 'civicrm/cividiscount/discount/copy',
           'qs' => '&cloneID=%%id%%&reset=1',
-          'title' => ts('Clone Discount Code')
+          'title' => E::ts('Clone Discount Code')
         ),
         CRM_Core_Action::DISABLE => array(
-          'name' => ts('Disable'),
+          'name' => E::ts('Disable'),
           'class' => 'crm-enable-disable',
-          'title' => ts('Disable Discount Code')
+          'title' => E::ts('Disable Discount Code')
         ),
         CRM_Core_Action::ENABLE => array(
-          'name' => ts('Enable'),
+          'name' => E::ts('Enable'),
           'class' => 'crm-enable-disable',
-          'title' => ts('Enable Discount Code')
+          'title' => E::ts('Enable Discount Code')
         ),
         CRM_Core_Action::DELETE => array(
-          'name' => ts('Delete'),
+          'name' => E::ts('Delete'),
           'url' => 'civicrm/cividiscount/discount/delete',
           'qs' => '&id=%%id%%',
-          'title' => ts('Delete Discount Code')
+          'title' => E::ts('Delete Discount Code')
         )
       );
     }
@@ -116,7 +117,7 @@ class CRM_CiviDiscount_Page_List extends CRM_Core_Page_Basic {
    * @return string name of this page.
    */
   function editName() {
-    return ts('Discount Code');
+    return E::ts('Discount Code');
   }
 
   /**

--- a/CRM/CiviDiscount/Page/View.php
+++ b/CRM/CiviDiscount/Page/View.php
@@ -30,6 +30,7 @@
  */
 
 require_once 'CRM/CiviDiscount/DAO/Item.php';
+use CRM_CiviDiscount_ExtensionUtil as E;
 
 /**
  * Page for displaying discount code details
@@ -70,26 +71,26 @@ class CRM_CiviDiscount_Page_View extends CRM_Core_Page {
     if (!(self::$_links)) {
       self::$_links = array(
         CRM_Core_Action::UPDATE => array(
-          'name' => ts('Edit'),
+          'name' => E::ts('Edit'),
           'url' => 'civicrm/cividiscount/discount/edit',
           'qs' => '&id=%%id%%&reset=1',
-          'title' => ts('Edit Discount')
+          'title' => E::ts('Edit Discount')
         ),
         CRM_Core_Action::DISABLE => array(
-          'name' => ts('Disable'),
+          'name' => E::ts('Disable'),
           'class' => 'crm-enable-disable',
-          'title' => ts('Disable Discount')
+          'title' => E::ts('Disable Discount')
         ),
         CRM_Core_Action::ENABLE => array(
-          'name' => ts('Enable'),
+          'name' => E::ts('Enable'),
           'class' => 'crm-enable-disable',
-          'title' => ts('Enable Discount')
+          'title' => E::ts('Enable Discount')
         ),
         CRM_Core_Action::DELETE => array(
-          'name' => ts('Delete'),
+          'name' => E::ts('Delete'),
           'url' => 'civicrm/cividiscount/discount/delete',
           'qs' => '&id=%%id%%&reset=1',
-          'title' => ts('Delete Discount')
+          'title' => E::ts('Delete Discount')
         )
       );
     }

--- a/cividiscount.civix.php
+++ b/cividiscount.civix.php
@@ -3,32 +3,116 @@
 // AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
 
 /**
- * (Delegated) Implementation of hook_civicrm_config
+ * The ExtensionUtil class provides small stubs for accessing resources of this
+ * extension.
+ */
+class CRM_CiviDiscount_ExtensionUtil {
+  const SHORT_NAME = "cividiscount";
+  const LONG_NAME = "org.civicrm.module.cividiscount";
+  const CLASS_PREFIX = "CRM_CiviDiscount";
+
+  /**
+   * Translate a string using the extension's domain.
+   *
+   * If the extension doesn't have a specific translation
+   * for the string, fallback to the default translations.
+   *
+   * @param string $text
+   *   Canonical message text (generally en_US).
+   * @param array $params
+   * @return string
+   *   Translated text.
+   * @see ts
+   */
+  public static function ts($text, $params = array()) {
+    if (!array_key_exists('domain', $params)) {
+      $params['domain'] = array(self::LONG_NAME, NULL);
+    }
+    return ts($text, $params);
+  }
+
+  /**
+   * Get the URL of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function url($file = NULL) {
+    if ($file === NULL) {
+      return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
+    }
+    return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
+  }
+
+  /**
+   * Get the path of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function path($file = NULL) {
+    // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+    return __DIR__ . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+  }
+
+  /**
+   * Get the name of a class within this extension.
+   *
+   * @param string $suffix
+   *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
+   * @return string
+   *   Ex: 'CRM_Foo_Page_HelloWorld'.
+   */
+  public static function findClass($suffix) {
+    return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
+  }
+
+}
+
+use CRM_CiviDiscount_ExtensionUtil as E;
+
+/**
+ * (Delegated) Implements hook_civicrm_config().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_config
  */
 function _cividiscount_civix_civicrm_config(&$config = NULL) {
   static $configured = FALSE;
-  if ($configured) return;
+  if ($configured) {
+    return;
+  }
   $configured = TRUE;
 
   $template =& CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname( __FILE__ ) . DIRECTORY_SEPARATOR;
+  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
-  if ( is_array( $template->template_dir ) ) {
-      array_unshift( $template->template_dir, $extDir );
-  } else {
-      $template->template_dir = array( $extDir, $template->template_dir );
+  if (is_array($template->template_dir)) {
+    array_unshift($template->template_dir, $extDir);
+  }
+  else {
+    $template->template_dir = array($extDir, $template->template_dir);
   }
 
-  $include_path = $extRoot . PATH_SEPARATOR . get_include_path( );
-  set_include_path( $include_path );
+  $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
+  set_include_path($include_path);
 }
 
 /**
- * (Delegated) Implementation of hook_civicrm_xmlMenu
+ * (Delegated) Implements hook_civicrm_xmlMenu().
  *
  * @param $files array(string)
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_xmlMenu
  */
 function _cividiscount_civix_civicrm_xmlMenu(&$files) {
   foreach (_cividiscount_civix_glob(__DIR__ . '/xml/Menu/*.xml') as $file) {
@@ -37,57 +121,82 @@ function _cividiscount_civix_civicrm_xmlMenu(&$files) {
 }
 
 /**
- * Implementation of hook_civicrm_install
+ * Implements hook_civicrm_install().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_install
  */
 function _cividiscount_civix_civicrm_install() {
   _cividiscount_civix_civicrm_config();
   if ($upgrader = _cividiscount_civix_upgrader()) {
-    return $upgrader->onInstall();
+    $upgrader->onInstall();
   }
 }
 
 /**
- * Implementation of hook_civicrm_uninstall
+ * Implements hook_civicrm_postInstall().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_postInstall
+ */
+function _cividiscount_civix_civicrm_postInstall() {
+  _cividiscount_civix_civicrm_config();
+  if ($upgrader = _cividiscount_civix_upgrader()) {
+    if (is_callable(array($upgrader, 'onPostInstall'))) {
+      $upgrader->onPostInstall();
+    }
+  }
+}
+
+/**
+ * Implements hook_civicrm_uninstall().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_uninstall
  */
 function _cividiscount_civix_civicrm_uninstall() {
   _cividiscount_civix_civicrm_config();
   if ($upgrader = _cividiscount_civix_upgrader()) {
-    return $upgrader->onUninstall();
+    $upgrader->onUninstall();
   }
 }
 
 /**
- * (Delegated) Implementation of hook_civicrm_enable
+ * (Delegated) Implements hook_civicrm_enable().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_enable
  */
 function _cividiscount_civix_civicrm_enable() {
   _cividiscount_civix_civicrm_config();
   if ($upgrader = _cividiscount_civix_upgrader()) {
     if (is_callable(array($upgrader, 'onEnable'))) {
-      return $upgrader->onEnable();
+      $upgrader->onEnable();
     }
   }
 }
 
 /**
- * (Delegated) Implementation of hook_civicrm_disable
+ * (Delegated) Implements hook_civicrm_disable().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_disable
+ * @return mixed
  */
 function _cividiscount_civix_civicrm_disable() {
   _cividiscount_civix_civicrm_config();
   if ($upgrader = _cividiscount_civix_upgrader()) {
     if (is_callable(array($upgrader, 'onDisable'))) {
-      return $upgrader->onDisable();
+      $upgrader->onDisable();
     }
   }
 }
 
 /**
- * (Delegated) Implementation of hook_civicrm_upgrade
+ * (Delegated) Implements hook_civicrm_upgrade().
  *
  * @param $op string, the type of operation being performed; 'check' or 'enqueue'
  * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
  *
  * @return mixed  based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
  *                for 'enqueue', returns void
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_upgrade
  */
 function _cividiscount_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
   if ($upgrader = _cividiscount_civix_upgrader()) {
@@ -95,10 +204,14 @@ function _cividiscount_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL)
   }
 }
 
+/**
+ * @return CRM_CiviDiscount_Upgrader
+ */
 function _cividiscount_civix_upgrader() {
-  if (!file_exists(__DIR__.'/CRM/CiviDiscount/Upgrader.php')) {
+  if (!file_exists(__DIR__ . '/CRM/CiviDiscount/Upgrader.php')) {
     return NULL;
-  } else {
+  }
+  else {
     return CRM_CiviDiscount_Upgrader_Base::instance();
   }
 }
@@ -131,7 +244,8 @@ function _cividiscount_civix_find_files($dir, $pattern) {
       while (FALSE !== ($entry = readdir($dh))) {
         $path = $subdir . DIRECTORY_SEPARATOR . $entry;
         if ($entry{0} == '.') {
-        } elseif (is_dir($path)) {
+        }
+        elseif (is_dir($path)) {
           $todos[] = $path;
         }
       }
@@ -141,9 +255,11 @@ function _cividiscount_civix_find_files($dir, $pattern) {
   return $result;
 }
 /**
- * (Delegated) Implementation of hook_civicrm_managed
+ * (Delegated) Implements hook_civicrm_managed().
  *
  * Find any *.mgd.php files, merge their content, and return.
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_managed
  */
 function _cividiscount_civix_civicrm_managed(&$entities) {
   $mgdFiles = _cividiscount_civix_find_files(__DIR__, '*.mgd.php');
@@ -151,10 +267,67 @@ function _cividiscount_civix_civicrm_managed(&$entities) {
     $es = include $file;
     foreach ($es as $e) {
       if (empty($e['module'])) {
-        $e['module'] = 'org.civicrm.module.cividiscount';
+        $e['module'] = E::LONG_NAME;
       }
       $entities[] = $e;
+      if (empty($e['params']['version'])) {
+        $e['params']['version'] = '3';
+      }
     }
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_caseTypes().
+ *
+ * Find any and return any files matching "xml/case/*.xml"
+ *
+ * Note: This hook only runs in CiviCRM 4.4+.
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_caseTypes
+ */
+function _cividiscount_civix_civicrm_caseTypes(&$caseTypes) {
+  if (!is_dir(__DIR__ . '/xml/case')) {
+    return;
+  }
+
+  foreach (_cividiscount_civix_glob(__DIR__ . '/xml/case/*.xml') as $file) {
+    $name = preg_replace('/\.xml$/', '', basename($file));
+    if ($name != CRM_Case_XMLProcessor::mungeCaseType($name)) {
+      $errorMessage = sprintf("Case-type file name is malformed (%s vs %s)", $name, CRM_Case_XMLProcessor::mungeCaseType($name));
+      CRM_Core_Error::fatal($errorMessage);
+      // throw new CRM_Core_Exception($errorMessage);
+    }
+    $caseTypes[$name] = array(
+      'module' => E::LONG_NAME,
+      'name' => $name,
+      'file' => $file,
+    );
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_angularModules().
+ *
+ * Find any and return any files matching "ang/*.ang.php"
+ *
+ * Note: This hook only runs in CiviCRM 4.5+.
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
+ */
+function _cividiscount_civix_civicrm_angularModules(&$angularModules) {
+  if (!is_dir(__DIR__ . '/ang')) {
+    return;
+  }
+
+  $files = _cividiscount_civix_glob(__DIR__ . '/ang/*.ang.php');
+  foreach ($files as $file) {
+    $name = preg_replace(':\.ang\.php$:', '', basename($file));
+    $module = include $file;
+    if (empty($module['ext'])) {
+      $module['ext'] = E::LONG_NAME;
+    }
+    $angularModules[$name] = $module;
   }
 }
 
@@ -166,7 +339,7 @@ function _cividiscount_civix_civicrm_managed(&$entities) {
  * result for an empty match is sometimes array() and sometimes FALSE.
  * This wrapper provides consistency.
  *
- * @see http://php.net/glob
+ * @link http://php.net/glob
  * @param string $pattern
  * @return array, possibly empty
  */
@@ -176,40 +349,97 @@ function _cividiscount_civix_glob($pattern) {
 }
 
 /**
- * Inserts a navigation menu item at a given place in the hierarchy
+ * Inserts a navigation menu item at a given place in the hierarchy.
  *
- * $menu - menu hierarchy
- * $path - path where insertion should happen (ie. Administer/System Settings)
- * $item - menu you need to insert (parent/child attributes will be filled for you)
- * $parentId - used internally to recurse in the menu structure
+ * @param array $menu - menu hierarchy
+ * @param string $path - path where insertion should happen (ie. Administer/System Settings)
+ * @param array $item - menu you need to insert (parent/child attributes will be filled for you)
  */
-function _cividiscount_civix_insert_navigation_menu(&$menu, $path, $item, $parentId = NULL) {
-  static $navId;
-
+function _cividiscount_civix_insert_navigation_menu(&$menu, $path, $item) {
   // If we are done going down the path, insert menu
   if (empty($path)) {
-    if (!$navId) $navId = CRM_Core_DAO::singleValueQuery("SELECT max(id) FROM civicrm_navigation");
-    $navId ++;
-    $menu[$navId] = array (
-      'attributes' => array_merge($item, array(
+    $menu[] = array(
+      'attributes' => array_merge(array(
         'label'      => CRM_Utils_Array::value('name', $item),
         'active'     => 1,
-        'parentID'   => $parentId,
-        'navID'      => $navId,
-      ))
+      ), $item),
     );
-    return true;
-  } else {
+    return TRUE;
+  }
+  else {
     // Find an recurse into the next level down
-    $found = false;
+    $found = FALSE;
     $path = explode('/', $path);
     $first = array_shift($path);
     foreach ($menu as $key => &$entry) {
       if ($entry['attributes']['name'] == $first) {
-        if (!$entry['child']) $entry['child'] = array();
+        if (!isset($entry['child'])) {
+          $entry['child'] = array();
+        }
         $found = _cividiscount_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item, $key);
       }
     }
     return $found;
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_navigationMenu().
+ */
+function _cividiscount_civix_navigationMenu(&$nodes) {
+  if (!is_callable(array('CRM_Core_BAO_Navigation', 'fixNavigationMenu'))) {
+    _cividiscount_civix_fixNavigationMenu($nodes);
+  }
+}
+
+/**
+ * Given a navigation menu, generate navIDs for any items which are
+ * missing them.
+ */
+function _cividiscount_civix_fixNavigationMenu(&$nodes) {
+  $maxNavID = 1;
+  array_walk_recursive($nodes, function($item, $key) use (&$maxNavID) {
+    if ($key === 'navID') {
+      $maxNavID = max($maxNavID, $item);
+    }
+  });
+  _cividiscount_civix_fixNavigationMenuItems($nodes, $maxNavID, NULL);
+}
+
+function _cividiscount_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
+  $origKeys = array_keys($nodes);
+  foreach ($origKeys as $origKey) {
+    if (!isset($nodes[$origKey]['attributes']['parentID']) && $parentID !== NULL) {
+      $nodes[$origKey]['attributes']['parentID'] = $parentID;
+    }
+    // If no navID, then assign navID and fix key.
+    if (!isset($nodes[$origKey]['attributes']['navID'])) {
+      $newKey = ++$maxNavID;
+      $nodes[$origKey]['attributes']['navID'] = $newKey;
+      $nodes[$newKey] = $nodes[$origKey];
+      unset($nodes[$origKey]);
+      $origKey = $newKey;
+    }
+    if (isset($nodes[$origKey]['child']) && is_array($nodes[$origKey]['child'])) {
+      _cividiscount_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
+    }
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_alterSettingsFolders().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders
+ */
+function _cividiscount_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
+  static $configured = FALSE;
+  if ($configured) {
+    return;
+  }
+  $configured = TRUE;
+
+  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
+  if (is_dir($settingsDir) && !in_array($settingsDir, $metaDataFolders)) {
+    $metaDataFolders[] = $settingsDir;
   }
 }

--- a/cividiscount.php
+++ b/cividiscount.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once 'cividiscount.civix.php';
+use CRM_CiviDiscount_ExtensionUtil as E;
 
 /**
  * Implements hook_civicrm_install().
@@ -89,7 +90,7 @@ function cividiscount_civicrm_tabs(&$tabs, $cid) {
     $tabs[] = array(
       'id' => 'discounts',
       'count' => $count,
-      'title' => ts('Codes Assigned'),
+      'title' => E::ts('Codes Assigned'),
       'weight' => '98',
       'url' => CRM_Utils_System::url('civicrm/cividiscount/usage', "reset=1&oid={$cid}", false, null, false),
     );
@@ -99,7 +100,7 @@ function cividiscount_civicrm_tabs(&$tabs, $cid) {
   $tabs[] = array(
     'id' => 'discounts',
     'count' => $count,
-    'title' => ts('Codes Redeemed'),
+    'title' => E::ts('Codes Redeemed'),
     'weight' => '99',
     'url' => CRM_Utils_System::url('civicrm/cividiscount/usage', "reset=1&cid={$cid}", false, null, false),
   );
@@ -238,7 +239,7 @@ function cividiscount_civicrm_validateForm($name, &$fields, &$files, &$form, &$e
   if ((!$discountInfo || !$discountInfo['autodiscount']) && trim($code) != '') {
 
     if (!$discountInfo) {
-      $errors['discountcode'] = ts('The discount code you entered is invalid.');
+      $errors['discountcode'] = E::ts('The discount code you entered is invalid.');
       return;
     }
 
@@ -252,7 +253,7 @@ function cividiscount_civicrm_validateForm($name, &$fields, &$files, &$form, &$e
         $apcount += $sv['additional_participants'];
       }
       if (($discount['count_use'] + $apcount) > $discount['count_max']) {
-        $errors['discountcode'] = ts('There are not enough uses remaining for this code.');
+        $errors['discountcode'] = E::ts('There are not enough uses remaining for this code.');
       }
     }
   }
@@ -340,7 +341,7 @@ function cividiscount_civicrm_buildAmount($pageType, &$form, &$amounts) {
     $discounts = $discountCalculator->getDiscounts();
 
      if (!empty($code) && empty($discounts)) {
-       $form->set( 'discountCodeErrorMsg', ts('The discount code you entered is invalid.'));
+       $form->set( 'discountCodeErrorMsg', E::ts('The discount code you entered is invalid.'));
     }
 
     // here we check if discount is configured for events or for membership types.
@@ -497,7 +498,7 @@ function _cividiscount_checkEventDiscountMultipleParticipants($pageType, &$form,
         $apcount += $sv['additional_participants'];
       }
       if (($discount['count_use'] + $apcount) > $discount['count_max']) {
-        $form->set('discountCodeErrorMsg', ts('There are not enough uses remaining for this code.'));
+        $form->set('discountCodeErrorMsg', E::ts('There are not enough uses remaining for this code.'));
         return FALSE;
       }
     }
@@ -584,7 +585,7 @@ function cividiscount_civicrm_membershipTypeValues(&$form, &$membershipTypeValue
     $discounts = $discountCalculator->getDiscounts();
   }
   if(!empty($code) && empty($discounts)) {
-    $form->set( 'discountCodeErrorMsg', ts('The discount code you entered is invalid.'));
+    $form->set( 'discountCodeErrorMsg', E::ts('The discount code you entered is invalid.'));
   }
   if (empty($discounts)) {
     return;
@@ -893,7 +894,7 @@ function _cividiscount_filter_membership_discounts($discounts, $membershipTypeVa
  * Calculate either a monetary or percentage discount.
  */
 function _cividiscount_calc_discount($amount, $label, $discount, $autodiscount, $currency = 'USD') {
-  $title = $autodiscount ? ts('Includes automatic member discount of') : ts('Includes applied discount code %1', array(1 => $discount['code']));
+  $title = $autodiscount ? E::ts('Includes automatic member discount of') : E::ts('Includes applied discount code %1', array(1 => $discount['code']));
   if ($discount['amount_type'] == '2') {
     $newamount = CRM_Utils_Rule::cleanMoney($amount) - CRM_Utils_Rule::cleanMoney($discount['amount']);
     $fmt_discount = CRM_Utils_Money::format($discount['amount'], $currency);
@@ -1042,14 +1043,14 @@ function _cividiscount_add_discount_textfield(&$form) {
     _cividiscount_add_button_before_priceSet($form);
     return;
   }
-  $form->addElement('text', 'discountcode', ts('If you have a discount code, enter it here'));
+  $form->addElement('text', 'discountcode', E::ts('If you have a discount code, enter it here'));
   $errorMessage = $form->get('discountCodeErrorMsg');
   if ($errorMessage) {
     $form->setElementError('discountcode', $errorMessage);
   }
   $form->set('discountCodeErrorMsg', null);
   $buttonName = $form->getButtonName('reload');
-  $form->addElement('submit', $buttonName, ts('Apply'), array('formnovalidate' => 1));
+  $form->addElement('submit', $buttonName, E::ts('Apply'), array('formnovalidate' => 1));
   $template = CRM_Core_Smarty::singleton();
   $bhfe = $template->get_template_vars('beginHookFormElements');
   if (!$bhfe) {
@@ -1100,7 +1101,7 @@ function _cividiscount_add_button_before_priceSet(&$form) {
   $form->add(
     'text',
     'discountcode',
-    ts('If you have a discount code, enter it here'),
+    E::ts('If you have a discount code, enter it here'),
     array('class' => 'description')
   );
   $errorMessage = $form->get('discountCodeErrorMsg');
@@ -1109,7 +1110,7 @@ function _cividiscount_add_button_before_priceSet(&$form) {
   }
   $form->set('discountCodeErrorMsg', null);
   $buttonName = $form->getButtonName('reload');
-  $form->addElement('submit', $buttonName, ts('Apply'), array('formnovalidate' => 1));
+  $form->addElement('submit', $buttonName, E::ts('Apply'), array('formnovalidate' => 1));
   $form->assign('discountElements', array(
     'discountcode',
     $buttonName


### PR DESCRIPTION
This PR updates the `cividiscount.civix.php` file so that we can use `E::ts()` to support translation.

Once that's done, we can drop-in the `cividiscount.mo` files from Transifex and use CiviDiscount in another language.

![cividiscount-translation](https://user-images.githubusercontent.com/254741/30710113-7ec40aa8-9ed2-11e7-86e6-a7af2d1add06.jpg)
