### PR TITLE
CRM-21636: Incorrect price amount when discount is applied (4.7.29 regression)

### DIFF
--- a/cividiscount.php
+++ b/cividiscount.php
@@ -412,7 +412,7 @@ function cividiscount_civicrm_buildAmount($pageType, &$form, &$amounts) {
           foreach ($fee['options'] as $option_id => &$option) {
             if (!empty($applyToAllLineItems) || CRM_Utils_Array::value($option['id'], $priceFields)) {
               $originalLabel = $originalAmounts[$fee_id]['options'][$option_id]['label'];
-              $originalAmount = CRM_Utils_Rule::cleanMoney($originalAmounts[$fee_id]['options'][$option_id]['amount']);
+              $originalAmount = $originalAmounts[$fee_id]['options'][$option_id]['amount'];
               list($amount, $label) =
                 _cividiscount_calc_discount($originalAmount, $originalLabel, $discount, $autodiscount, $currency);
               $discountAmount = $originalAmounts[$fee_id]['options'][$option_id]['amount'] - $amount;
@@ -429,7 +429,7 @@ function cividiscount_civicrm_buildAmount($pageType, &$form, &$amounts) {
                 $recalculateTaxAmount = array();
                 if (array_key_exists('tax_amount', $originalAmounts[$fee_id]['options'][$option_id]) &&
                     array_key_exists('tax_rate', $originalAmounts[$fee_id]['options'][$option_id])) {
-                  $recalculateTaxAmount = CRM_Contribute_BAO_Contribution_Utils::calculateTaxAmount($amount, $originalAmounts[$fee_id]['options'][$option_id]['tax_rate']);
+                  $recalculateTaxAmount = CRM_Contribute_BAO_Contribution_Utils::calculateTaxAmount($amount, $originalAmounts[$fee_id]['options'][$option_id]['tax_rate'], TRUE);
                   if (!empty($recalculateTaxAmount)) {
                     $option['tax_amount'] = round($recalculateTaxAmount['tax_amount'], 2);
                   }
@@ -898,7 +898,7 @@ function _cividiscount_filter_membership_discounts($discounts, $membershipTypeVa
 function _cividiscount_calc_discount($amount, $label, $discount, $autodiscount, $currency = 'USD') {
   $title = $autodiscount ? E::ts('Includes automatic member discount of') : E::ts('Includes applied discount code %1', array(1 => $discount['code']));
   if ($discount['amount_type'] == '2') {
-    $newamount = CRM_Utils_Rule::cleanMoney($amount) - CRM_Utils_Rule::cleanMoney($discount['amount']);
+    $newamount = $amount - $discount['amount'];
     $fmt_discount = CRM_Utils_Money::format($discount['amount'], $currency);
     $newlabel = $label . " ({$title}: {$fmt_discount} {$discount['description']})";
 


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate: 
1. Use . (dot) and , (comma) as thousand and decimal separator respectively. 
2. Configure a discount code, to be used against even or membership. (I choose 63% discount for an Event) 
3. Go to event page/membership signup page and apply the discount code. Lets say 63% discount amount - $100

Before
----------------------------------------
![screen shot 2018-01-09 at 2 58 09 pm](https://user-images.githubusercontent.com/3735621/34713868-8f155caa-f54d-11e7-9174-87acb645fc27.png)

After
----------------------------------------
![screen shot 2018-01-09 at 2 56 45 pm](https://user-images.githubusercontent.com/3735621/34713826-6ea67f58-f54d-11e7-89fe-3e7d1912d337.png)
